### PR TITLE
Ability to serialize the API object.

### DIFF
--- a/src/Authenticator.php
+++ b/src/Authenticator.php
@@ -9,14 +9,13 @@ use GuzzleHttp\Exception\GuzzleException;
 
 class Authenticator
 {
-    private Client $httpClient;
     private string $cacheKeyTokens = 'ERGONODE_API_TOKENS';
     private string $bearerToken;
     private string $refreshToken;
 
-    public function __construct(Client $httpClient)
+    public function __construct(private Client $httpClient)
     {
-        $this->httpClient = $httpClient;
+
     }
 
     public function authenticate(string $username, string $password): void
@@ -86,5 +85,26 @@ class Authenticator
     public function setRefreshToken(string $refreshToken): void
     {
         $this->refreshToken = $refreshToken;
+    }
+
+    public function setHttpClient(Client $httpClient): void
+    {
+        $this->httpClient = $httpClient;
+    }
+
+    public function __serialize(): array
+    {
+        return [
+            'cacheKeyTokens' => $this->cacheKeyTokens,
+            'bearerToken'    => $this->bearerToken,
+            'refreshToken'   => $this->refreshToken,
+        ];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        $this->cacheKeyTokens = $data['cacheKeyTokens'];
+        $this->bearerToken    = $data['bearerToken'];
+        $this->refreshToken   = $data['refreshToken'];
     }
 }

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -17,7 +17,7 @@ class Connector
     private Client $httpClient;
     private Authenticator $authenticator;
 
-    public function __construct(private string $locale, string $hostname, string $username, string $password)
+    public function __construct(private string $locale, private string $hostname, string $username, string $password)
     {
         $this->httpClient = new Client([
             'base_uri' => $hostname,
@@ -84,5 +84,27 @@ class Connector
     public function getLocale(): string
     {
         return $this->locale;
+    }
+
+    public function __serialize(): array
+    {
+        return [
+            'locale'        => $this->locale,
+            'hostname'      => $this->hostname,
+            'authenticator' => $this->authenticator,
+        ];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        $this->locale        = $data['locale'];
+        $this->hostname      = $data['hostname'];
+        $this->authenticator = $data['authenticator'];
+
+        $this->httpClient = new Client([
+            'base_uri' => $this->hostname,
+        ]);
+
+        $this->authenticator->setHttpClient($this->httpClient);
     }
 }


### PR DESCRIPTION
We encountered a bug in Laravel. It would not let us do standard validation on a request.

The error we got was the following:
Exception: Serialization of 'Closure' is not allowed

Upon further investigation we found out that the problem was with Guzzle.
Guzzle uses Closures, which can't be serialized.

By manually serializing and unserializing the Connector and Authenticator we made it possible to serialize the object.