### PR TITLE
Avoid fatal exception when authenticating

### DIFF
--- a/src/Authenticator.php
+++ b/src/Authenticator.php
@@ -50,7 +50,9 @@ class Authenticator
             $response = $this->httpClient->post('login', $options);
 
         } catch (GuzzleException $exception) {
-            throw $exception;
+            $this->setBearerToken('');
+            $this->setRefreshToken('');
+            return;
         }
 
         $tokens = json_decode($response->getBody());


### PR DESCRIPTION
When authenticating with invalid values you will get a guzzleException, that it either cannot resolve the domain name or the login values are invalid.

Instead of letting it throw this error we set empty tokens so when why try to make another request we will get a 401 error. We can catch this error in the application that is using the package.